### PR TITLE
Bugfixes in source output, and output in diff format by default

### DIFF
--- a/src/vendetect/_cli.py
+++ b/src/vendetect/_cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TextIO
 
 from rich import traceback
-from rich.console import Console
+from rich.console import Console, ConsoleRenderable
 from rich.logging import RichHandler
 from rich.panel import Panel
 from rich.progress import Progress, TaskID
@@ -235,13 +235,13 @@ def output_rich(  # noqa: PLR0912 PLR0915 C901
                         else:
                             status_col = Text("✓", style="green reverse")
                         if diff_line.left is None:
-                            left = Text("")
+                            left: ConsoleRenderable = Text("")
                         else:
                             left = Syntax(
                                 diff_line.left, lexer=test_lexer, line_numbers=True, start_line=diff_line.left_line
                             )
                         if diff_line.right is None:
-                            right = Text("")
+                            right: ConsoleRenderable = Text("")
                         else:
                             right = Syntax(
                                 diff_line.right, lexer=source_lexer, line_numbers=True, start_line=diff_line.right_line

--- a/src/vendetect/diffing.py
+++ b/src/vendetect/diffing.py
@@ -17,9 +17,9 @@ class Rounding(Enum):
 
 class DiffLine:
     def __init__(self, left: str | None, status: DiffLineStatus, right: str | None, left_line: int, right_line: int):
-        self.left: str = left
+        self.left: str | None = left
         self.status: DiffLineStatus = status
-        self.right: str = right
+        self.right: str | None = right
         self.left_line: int = left_line
         self.right_line: int = right_line
 
@@ -29,6 +29,8 @@ class CollapsedDiffLine(DiffLine):
         self.left_start_line: int = left_start_line
         self.right_start_line: int = right_start_line
         self.num_identical_lines: int = num_identical_lines
+        self.left: str
+        self.right: str
         super().__init__(
             f"<{self.num_identical_lines} identical lines starting on line {self.left_start_line}>",
             DiffLineStatus.COPIED,


### PR DESCRIPTION
- Fixes a bug in which we were confusing byte offsets for line number offsets
- Outputs to the console in a much nicer diff format