### PR TITLE
typo fix in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ mypy
 If you'd like to file a bug report or feature request, please use our
 [issues](https://github.com/trailofbits/deptective/issues) page.
 Feel free to contact us or reach out in
-[Empire Hacking](https://slack.empirehacking.nyc/) for help using or extending Deptective.
+[Empire Hacking](https://slack.empirehacking.nyc/) for help using or extending Vendetect.
 
 ## License 📝
 


### PR DESCRIPTION
Hi there,

the README mentioned "Deptective", which is probably an (internal) project name. This PR changes it to "Vendetect".

Cheers,
tpltnt